### PR TITLE
Fix undefined variable warnings in caption syntax handler

### DIFF
--- a/syntax/caption.php
+++ b/syntax/caption.php
@@ -118,7 +118,7 @@ class syntax_plugin_latexcaption_caption extends \dokuwiki\Extension\SyntaxPlugi
                     $parcount = $this->{'_'.$partype.'_count'};
                 }
                 // Get caption metadata ready for use in reference syntax. Also store in global array for preview to render correctly
-                $this->caption_count[$label] = array($type, $type_counter, $parcount);
+                $this->caption_count[$label] = array($type, $type_counter, $parcount ?? null);
                 $caption_count = $this->caption_count;
             }
 
@@ -258,7 +258,7 @@ class syntax_plugin_latexcaption_caption extends \dokuwiki\Extension\SyntaxPlugi
 
                 // Rendering a caption
                 if ($incaption) {
-                    $markup .= '<'.$captagtype.' class="plugin_latexcaption_caption"><span class="plugin_latexcaption_caption_number"';
+                    $markup = '<'.$captagtype.' class="plugin_latexcaption_caption"><span class="plugin_latexcaption_caption_number"';
                     // Set title to label
                     // if ($label) $markup .= ' title="'.$label.'"';
                     $markup .= '>';


### PR DESCRIPTION
## Summary
Encountered this PHP warning on a production site (DokuWiki 2025-05-14a "Librarian", PHP 8.3.x):

```Warning: Undefined variable $markup in syntax/caption.php on line 261```

While investigating, I found issue https://github.com/bennvan/dokuwiki-plugin-latexcaption/issues/5 which reports the same warning plus another:
```Warning: Undefined variable $parcount in syntax/caption.php on line 121```

## Fix
- **Line 121**: `$parcount` → `$parcount ?? null` -> `$parcount` is only set inside a conditional `isSubType()` block, so it may be undefined.
- **Line 261**: `$markup .=` → `$markup =` -> `$markup` is never initialized before the append operation in the `$incaption` branch.